### PR TITLE
Fix special chars

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
     readr,
     readxl,
     feather,
-    magrittr
+    magrittr,
+    utils
 Suggests: 
     testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: egnyter
 Type: Package
 Title: Read and Write Data to Egnyte from R
-Version: 1.0.4
+Version: 1.0.5
 Author: Josh Muncke
 Maintainer: Josh Muncke <josh.muncke@redbull.com>
 Description: The egnyter package allows you to read and write data

--- a/R/authenticate_user.R
+++ b/R/authenticate_user.R
@@ -41,6 +41,10 @@ authenticate_user <- function(domain, app_key, username, password) {
   # Add a trailing '/' if not given
   if(stringr::str_sub(domain, -1) != "/") { domain <- paste0(domain,"/") }
 
+  # URL encode username and password
+  username = utils::URLencode(username)
+  password = utils::URLencode(password)
+
   # Create the url and body of the auth call
   authentication_url <- paste0(domain, "puboauth/token")
   authentication_string <- paste0("client_id=", app_key, "&username=", username, "&password=", password, "&grant_type=password")


### PR DESCRIPTION
URL encode the username and password parameters to prevent authentication if there are special characters. fixes #5 .