### PR TITLE
updates to Egnyte API require client_secret

### DIFF
--- a/R/authenticate_user.R
+++ b/R/authenticate_user.R
@@ -49,7 +49,7 @@ authenticate_user <- function(domain, app_key, app_secret, username, password) {
   # Create the url and body of the auth call
   authentication_url <- paste0(domain, "puboauth/token")
   authentication_string <- paste0("client_id=", app_key,
-                                  "client_secret=", app_secret,
+                                  "&client_secret=", app_secret,
                                   "&username=", username,
                                   "&password=", password,
                                   "&grant_type=password")

--- a/R/authenticate_user.R
+++ b/R/authenticate_user.R
@@ -16,10 +16,11 @@
 #'
 #' @param domain the URL of your Egnyte domain
 #' @param app_key API key of your Egnyte application
+#' @param app_secret API secret key of your Egnyte application (new as of 2019)
 #' @param username user's Egnyte username
 #' @param password user's Egnyte password
 #' @export
-authenticate_user <- function(domain, app_key, username, password) {
+authenticate_user <- function(domain, app_key, app_secret, username, password) {
   # Check domain
   if(!validate_domain(domain)) {
     stop("Invalid Egnyte domain.",
@@ -47,7 +48,11 @@ authenticate_user <- function(domain, app_key, username, password) {
 
   # Create the url and body of the auth call
   authentication_url <- paste0(domain, "puboauth/token")
-  authentication_string <- paste0("client_id=", app_key, "&username=", username, "&password=", password, "&grant_type=password")
+  authentication_string <- paste0("client_id=", app_key,
+                                  "client_secret=", app_secret,
+                                  "&username=", username,
+                                  "&password=", password,
+                                  "&grant_type=password")
 
   # Form the auth request
   auth_request <- httr::POST(

--- a/R/token.R
+++ b/R/token.R
@@ -7,10 +7,11 @@
 #'
 #' @param domain the URL of your Egnyte domain
 #' @param app_key API key of your Egnyte application
+#' @param app_secret API secret key of your Egnyte application (new as of 2019)
 #' @param username user's Egnyte username
 #' @param password user's Egnyte password
 #' @export
-set_token <- function(domain, app_key, username, password) {
+set_token <- function(domain, app_key, app_secret, username, password) {
   # Check domain
   if(!validate_domain(domain)) {
     stop("Invalid Egnyte domain.",
@@ -23,7 +24,7 @@ set_token <- function(domain, app_key, username, password) {
          call. = FALSE)
   }
 
-  token_value <- authenticate_user(domain, app_key, username, password)
+  token_value <- authenticate_user(domain, app_key, app_secret, username, password)
 
   options(egnyter.auth_token = token_value)
   options(egnyter.domain = domain)

--- a/man/authenticate_user.Rd
+++ b/man/authenticate_user.Rd
@@ -11,6 +11,8 @@ authenticate_user(domain, app_key, username, password)
 
 \item{app_key}{API key of your Egnyte application}
 
+\item{app_secret}{API secret key of your Egnyte application}
+
 \item{username}{user's Egnyte username}
 
 \item{password}{user's Egnyte password}

--- a/man/set_token.Rd
+++ b/man/set_token.Rd
@@ -11,6 +11,8 @@ set_token(domain, app_key, username, password)
 
 \item{app_key}{API key of your Egnyte application}
 
+\item{app_secret}{API secret key of your Egnyte application}
+
 \item{username}{user's Egnyte username}
 
 \item{password}{user's Egnyte password}


### PR DESCRIPTION
`client_secret` is now a required parameter within Egnyte API. updated authorization and token functions accordingly